### PR TITLE
Add cerebras dependency in quick start example

### DIFF
--- a/examples/quick-start/package.json
+++ b/examples/quick-start/package.json
@@ -2,6 +2,7 @@
 	"type": "module",
 	"name": "ui2-quick-start",
 	"dependencies": {
-		"ui2-sdk": "^0.1.0"
+		"ui2-sdk": "^0.1.0",
+		"@ai-sdk/cerebras": "^0.2.14"
 	}
 }


### PR DESCRIPTION
I believe this dependency was missing in the quick-start package.json, since without it, it wouldn't work 